### PR TITLE
Parallel RM clean - Saving residuals - Working progress bars

### DIFF
--- a/RMtools_1D/cl_RMclean_1D.py
+++ b/RMtools_1D/cl_RMclean_1D.py
@@ -51,7 +51,7 @@ from RMutils.util_RM import measure_fdf_complexity
 C = 2.997924538e8 # Speed of light [m/s]
 
 #-----------------------------------------------------------------------------#
-@profile
+#@profile
 def run_rmclean(mDictS, aDict, cutoff,
                 maxIter=1000, gain=0.1, prefixOut="", outDir="", nBits=32,
                 showPlots=False, doAnimate=False, verbose=False,log=print):

--- a/RMtools_1D/cl_RMclean_1D.py
+++ b/RMtools_1D/cl_RMclean_1D.py
@@ -51,6 +51,7 @@ from RMutils.util_RM import measure_fdf_complexity
 C = 2.997924538e8 # Speed of light [m/s]
 
 #-----------------------------------------------------------------------------#
+@profile
 def run_rmclean(mDictS, aDict, cutoff,
                 maxIter=1000, gain=0.1, prefixOut="", outDir="", nBits=32,
                 showPlots=False, doAnimate=False, verbose=False,log=print):
@@ -125,12 +126,12 @@ def run_rmclean(mDictS, aDict, cutoff,
     # Measure the complexity of the clean component spectrum
     mDict["mom2CCFDF"] = measure_fdf_complexity(phiArr = phiArr_radm2,
                                                 FDF = ccArr)
-    
+
     #Calculating observed errors (based on dFDFcorMAD)
     mDict["dPhiObserved_rm2"] = mDict["dPhiPeakPIfit_rm2"]*mDict["dFDFcorMAD_Jybm"]/mDictS["dFDFth_Jybm"]
     mDict["dAmpObserved_Jybm"] = mDict["dFDFcorMAD_Jybm"]
     mDict["dPolAngleFitObserved_deg"] = mDict["dPolAngleFit_deg"]*mDict["dFDFcorMAD_Jybm"]/mDictS["dFDFth_Jybm"]
-    
+
     nChansGood = np.sum(np.where(lambdaSqArr_m2==lambdaSqArr_m2, 1.0, 0.0))
     varLamSqArr_m2 = (np.sum(lambdaSqArr_m2**2.0) -
                       np.sum(lambdaSqArr_m2)**2.0/nChansGood) / (nChansGood-1)
@@ -138,7 +139,7 @@ def run_rmclean(mDictS, aDict, cutoff,
     np.degrees(np.sqrt( mDict["dFDFcorMAD_Jybm"]**2.0 / (4.0*(nChansGood-2.0)*mDict["ampPeakPIfit_Jybm"]**2.0) *
                  ((nChansGood-1)/nChansGood + mDictS["lam0Sq_m2"]**2.0/varLamSqArr_m2) ))
 
-    
+
     # Save the deconvolved FDF and CC model to ASCII files
     log("Saving the clean FDF and component model to ASCII files.")
     outFile = prefixOut + "_FDFclean.dat"
@@ -160,7 +161,7 @@ def run_rmclean(mDictS, aDict, cutoff,
     log("> %s" % outFile)
     json.dump(mDict, open(outFile, "w"))
 
-    
+
     # Print the results to the screen
     log()
     log('-'*80)
@@ -185,15 +186,15 @@ def run_rmclean(mDictS, aDict, cutoff,
     if showPlots or doAnimate:
         print("Press <RETURN> to exit ...", end=' ')
         input()
-        
+
     return mDict
-        
+
 def readFiles(fdfFile, rmsfFile, weightFile, rmSynthFile, nBits):
 
     # Default data types
     dtFloat = "float" + str(nBits)
     dtComplex = "complex" + str(2*nBits)
-        
+
     # Read the RMSF from the ASCII file
     phi2Arr_radm2, RMSFreal, RMSFimag = np.loadtxt(rmsfFile, unpack=True, dtype=dtFloat)
     # Read the frequency vector for the lambda^2 array
@@ -202,9 +203,9 @@ def readFiles(fdfFile, rmsfFile, weightFile, rmSynthFile, nBits):
     phiArr_radm2, FDFreal, FDFimag = np.loadtxt(fdfFile, unpack=True, dtype=dtFloat)
     # Read the RM-synthesis parameters from the JSON file
     mDictS = json.load(open(rmSynthFile, "r"))
-    dirtyFDF = FDFreal + 1j * FDFimag    
+    dirtyFDF = FDFreal + 1j * FDFimag
     RMSFArr = RMSFreal + 1j * RMSFimag
-    
+
     #add array dictionary
     aDict = dict()
     aDict["phiArr_radm2"] = phiArr_radm2
@@ -213,7 +214,7 @@ def readFiles(fdfFile, rmsfFile, weightFile, rmSynthFile, nBits):
     aDict["freqArr_Hz"] = freqArr_Hz
     aDict["weightArr"]=weightArr
     aDict["dirtyFDF"]=dirtyFDF
-    
+
     return mDictS, aDict
 
 

--- a/RMtools_1D/cl_RMclean_1D.py
+++ b/RMtools_1D/cl_RMclean_1D.py
@@ -51,10 +51,9 @@ from RMutils.util_RM import measure_fdf_complexity
 C = 2.997924538e8 # Speed of light [m/s]
 
 #-----------------------------------------------------------------------------#
-#@profile
 def run_rmclean(mDictS, aDict, cutoff,
                 maxIter=1000, gain=0.1, prefixOut="", outDir="", nBits=32,
-                showPlots=False, doAnimate=False, verbose=False,log=print):
+                showPlots=False, doAnimate=False, verbose=False,log=print, pool=None):
     """
     Run RM-CLEAN on a complex FDF spectrum given a RMSF.
     """
@@ -90,7 +89,8 @@ def run_rmclean(mDictS, aDict, cutoff,
                                 gain            = gain,
                                 verbose         = verbose,
                                 doPlots         = showPlots,
-                                doAnimate       = doAnimate)
+                                doAnimate       = doAnimate,
+                                pool            = pool)
 
     # ALTERNATIVE RM_CLEAN CODE ----------------------------------------------#
     '''

--- a/RMtools_1D/cl_RMclean_1D.py
+++ b/RMtools_1D/cl_RMclean_1D.py
@@ -77,7 +77,7 @@ def run_rmclean(mDictS, aDict, cutoff,
 
     startTime = time.time()
     # Perform RM-clean on the spectrum
-    cleanFDF, ccArr, iterCountArr = \
+    cleanFDF, ccArr, iterCountArr, residFDF = \
               do_rmclean_hogbom(dirtyFDF        = dirtyFDF,
                                 phiArr_radm2    = phiArr_radm2,
                                 RMSFArr         = RMSFArr,
@@ -140,13 +140,16 @@ def run_rmclean(mDictS, aDict, cutoff,
 
 
     # Save the deconvolved FDF and CC model to ASCII files
-    log("Saving the clean FDF and component model to ASCII files.")
+    log("Saving the clean FDF, component model, and residuals to ASCII files.")
     outFile = prefixOut + "_FDFclean.dat"
     log("> %s" % outFile)
     np.savetxt(outFile, list(zip(phiArr_radm2, cleanFDF.real, cleanFDF.imag)))
     outFile = prefixOut + "_FDFmodel.dat"
     log("> %s" % outFile)
     np.savetxt(outFile, list(zip(phiArr_radm2, ccArr.real, ccArr.imag)))
+    outFile = prefixOut + "_FDFresid.dat"
+    log("> %s" % outFile)
+    np.savetxt(outFile, list(zip(phiArr_radm2, residFDF.real, residFDF.imag)))
 
     # Save the RM-clean measurements to a "key=value" text file
     log("Saving the measurements on the FDF in 'key=val' and JSON formats.")

--- a/RMtools_1D/do_RMclean_1D.py
+++ b/RMtools_1D/do_RMclean_1D.py
@@ -37,6 +37,7 @@ import sys
 import os
 import time
 import argparse
+import schwimmbad
 
 import cl_RMclean_1D as clRM
 
@@ -64,7 +65,7 @@ def main():
     _RMclean.dat: list of calculated paramaters describing FDF
     _RMclean.json: dictionary of calculated parameters
     """
-    
+
     # Parse the command line options
     parser = argparse.ArgumentParser(description=descStr,epilog=epilog_text,
                                  formatter_class=argparse.RawTextHelpFormatter)
@@ -83,6 +84,15 @@ def main():
     parser.add_argument("-v", dest="verbose", action="store_true",
                         help="Print verbose messages")
 
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--ncores", dest="n_cores", default=1,
+                       type=int, help="Number of processes (uses multiprocessing).")
+    group.add_argument("--mpi", dest="mpi", default=False,
+                       action="store_true", help="Run with MPI.")
+    args = parser.parse_args()
+
+    pool = schwimmbad.choose_pool(mpi=args.mpi, processes=args.n_cores)
+
     args = parser.parse_args()
 
     # Form the input file names from prefix of the original data file
@@ -98,7 +108,7 @@ def main():
             sys.exit()
     nBits = 32
     dataDir, dummy = os.path.split(args.dataFile[0])
-    mDictS, aDict = clRM.readFiles(fdfFile, rmsfFile, weightFile, rmSynthFile, nBits)  
+    mDictS, aDict = clRM.readFiles(fdfFile, rmsfFile, weightFile, rmSynthFile, nBits)
     # Run RM-CLEAN on the spectrum
     clRM.run_rmclean(mDictS  = mDictS,
                 aDict        = aDict,
@@ -110,11 +120,12 @@ def main():
                 nBits        = nBits,
                 showPlots    = args.showPlots,
                 doAnimate    = args.doAnimate,
-                verbose      = args.verbose)
-    
+                verbose      = args.verbose,
+                pool         = pool)
 
 
-    
+
+
 #-----------------------------------------------------------------------------#
 if __name__ == "__main__":
     main()

--- a/RMtools_3D/do_RMclean_3D.py
+++ b/RMtools_3D/do_RMclean_3D.py
@@ -82,7 +82,7 @@ def main():
     parser.add_argument("-f", dest="write_separate_FDF", action="store_true",
                         help="Separate complex (multi-extension) FITS files into individual files [False].")
     parser.add_argument("-v", dest="verbose", action="store_true",
-                        help="Verbose [False].")
+                        help="Verbose [False].", default=False)
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--ncores", dest="n_cores", default=1,
                        type=int, help="Number of processes (uses multiprocessing).")
@@ -123,13 +123,14 @@ def main():
                 nBits=32,
                 write_separate_FDF=args.write_separate_FDF,
                 pool=pool,
-                chunksize=chunksize)
+                chunksize=chunksize,
+                verbose=verbose)
 
 #-----------------------------------------------------------------------------#
 
 
 def run_rmclean(fitsFDF, fitsRMSF, cutoff_mJy, maxIter=1000, gain=0.1,
-                prefixOut="", outDir="", nBits=32, write_separate_FDF=False, verbose=True, log=print, pool=None, chunksize=None, verbose=verbose):
+                prefixOut="", outDir="", nBits=32, write_separate_FDF=False, log=print, pool=None, chunksize=None, verbose=False):
     """Run RM-CLEAN on a FDF cube given a RMSF cube."""
 
     # Default data types
@@ -161,7 +162,6 @@ def run_rmclean(fitsFDF, fitsRMSF, cutoff_mJy, maxIter=1000, gain=0.1,
                           cutoff=cutoff_mJy,
                           maxIter=maxIter,
                           gain=gain,
-                          verbose=True,
                           doPlots=False,
                           pool=pool,
                           chunksize=chunksize,

--- a/RMtools_3D/do_RMclean_3D.py
+++ b/RMtools_3D/do_RMclean_3D.py
@@ -83,7 +83,7 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--ncores", dest="n_cores", default=1,
                        type=int, help="Number of processes (uses multiprocessing).")
-    group.add_argument("--chunk", dest="chunk", default=None,
+    parser.add_argument("--chunk", dest="chunk", default=None,
                        type=int, help="Chunk size (uses multiprocessing -- not available in MPI!)")
     group.add_argument("--mpi", dest="mpi", default=False,
                        action="store_true", help="Run with MPI.")

--- a/RMtools_3D/do_RMclean_3D.py
+++ b/RMtools_3D/do_RMclean_3D.py
@@ -46,11 +46,12 @@ import schwimmbad
 from RMutils.util_RM import do_rmclean_hogbom
 from RMutils.util_RM import fits_make_lin_axis
 
-C = 2.997924538e8 # Speed of light [m/s]
+C = 2.997924538e8  # Speed of light [m/s]
 
 #-----------------------------------------------------------------------------#
-def main():
 
+
+def main():
     """
     Start the function to perform RM-clean if called from the command line.
     """
@@ -103,7 +104,6 @@ def main():
     else:
         chunksize = None
 
-
     verbose = args.verbose
     # Sanity checks
     for f in args.fitsFDF + args.fitsRMSF:
@@ -113,22 +113,23 @@ def main():
     dataDir, dummy = os.path.split(args.fitsFDF[0])
 
     # Run RM-CLEAN on the cubes
-    run_rmclean(fitsFDF     = args.fitsFDF[0],
-                fitsRMSF    = args.fitsRMSF[0],
-                cutoff_mJy  = args.cutoff_mJy,
-                maxIter     = args.maxIter,
-                gain        = args.gain,
-                prefixOut   = args.prefixOut,
-                outDir      = dataDir,
-                nBits       = 32,
+    run_rmclean(fitsFDF=args.fitsFDF[0],
+                fitsRMSF=args.fitsRMSF[0],
+                cutoff_mJy=args.cutoff_mJy,
+                maxIter=args.maxIter,
+                gain=args.gain,
+                prefixOut=args.prefixOut,
+                outDir=dataDir,
+                nBits=32,
                 write_separate_FDF=args.write_separate_FDF,
-                pool = pool,
-                chunksize   = chunksize)
+                pool=pool,
+                chunksize=chunksize)
 
 #-----------------------------------------------------------------------------#
+
+
 def run_rmclean(fitsFDF, fitsRMSF, cutoff_mJy, maxIter=1000, gain=0.1,
-                prefixOut="", outDir="", nBits=32, write_separate_FDF=False, verbose = True, log = print, pool=None, chunksize=None):
-                verbose = verbose)
+                prefixOut="", outDir="", nBits=32, write_separate_FDF=False, verbose=True, log=print, pool=None, chunksize=None, verbose=verbose):
     """Run RM-CLEAN on a FDF cube given a RMSF cube."""
 
     # Default data types
@@ -136,15 +137,13 @@ def run_rmclean(fitsFDF, fitsRMSF, cutoff_mJy, maxIter=1000, gain=0.1,
     dtComplex = "complex" + str(2*nBits)
 
     # Read the FDF
-    dirtyFDF, head,FD_axis=read_FDF_cube(fitsFDF)
-
-
+    dirtyFDF, head, FD_axis = read_FDF_cube(fitsFDF)
 
     phiArr_radm2 = fits_make_lin_axis(head, axis=FD_axis-1, dtype=dtFloat)
 
     # Read the RMSF
 
-    RMSFArr, headRMSF,FD_axis=read_FDF_cube(fitsRMSF)
+    RMSFArr, headRMSF, FD_axis = read_FDF_cube(fitsRMSF)
     HDULst = pf.open(fitsRMSF, "readonly", memmap=True)
     fwhmRMSFArr = HDULst[3].data
     HDULst.close()
@@ -153,94 +152,119 @@ def run_rmclean(fitsFDF, fitsRMSF, cutoff_mJy, maxIter=1000, gain=0.1,
     startTime = time.time()
 
     # Do the clean
-    cleanFDF, ccArr, iterCountArr = \
-        do_rmclean_hogbom(dirtyFDF         = dirtyFDF * 1e3,
-                          phiArr_radm2     = phiArr_radm2,
-                          RMSFArr          = RMSFArr,
-                          phi2Arr_radm2    = phi2Arr_radm2,
-                          fwhmRMSFArr      = fwhmRMSFArr,
-                          cutoff           = cutoff_mJy,
-                          maxIter          = maxIter,
-                          gain             = gain,
-                          verbose          = True,
-                          doPlots          = False,
-                          pool             = pool,
-                          chunksize        = chunksize,)
-                          verbose          = verbose)
+    cleanFDF, ccArr, iterCountArr, residFDF = \
+        do_rmclean_hogbom(dirtyFDF=dirtyFDF * 1e3,
+                          phiArr_radm2=phiArr_radm2,
+                          RMSFArr=RMSFArr,
+                          phi2Arr_radm2=phi2Arr_radm2,
+                          fwhmRMSFArr=fwhmRMSFArr,
+                          cutoff=cutoff_mJy,
+                          maxIter=maxIter,
+                          gain=gain,
+                          verbose=True,
+                          doPlots=False,
+                          pool=pool,
+                          chunksize=chunksize,
+                          verbose = verbose)
     cleanFDF /= 1e3
     ccArr /= 1e3
 
-    endTime = time.time()
-    cputime = (endTime - startTime)
+    endTime=time.time()
+    cputime=(endTime - startTime)
     if (verbose): log("> RM-clean completed in %.2f seconds." % cputime)
     if (verbose): log("Saving the clean FDF and ancillary FITS files")
 
 
-    if outDir=='':  #To prevent code breaking if file is in current directory
+    if outDir == '':  # To prevent code breaking if file is in current directory
         outDir='.'
 
-    #Move FD axis back to original position:
+    # Move FD axis back to original position:
     Ndim=cleanFDF.ndim
-    cleanFDF=np.moveaxis(cleanFDF,0,Ndim-FD_axis)
-    ccArr=np.moveaxis(ccArr,0,Ndim-FD_axis)
+    cleanFDF=np.moveaxis(cleanFDF, 0, Ndim-FD_axis)
+    ccArr=np.moveaxis(ccArr, 0, Ndim-FD_axis)
+    residFDF=np.moveaxis(residFDF, 0, Ndim-FD_axis)
 
 
     # Save the clean FDF
     if not write_separate_FDF:
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_clean.fits"
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_clean.fits"
         if(verbose): log("> %s" % fitsFileOut)
-        hdu0 = pf.PrimaryHDU(cleanFDF.real.astype(dtFloat), head)
-        hdu1 = pf.ImageHDU(cleanFDF.imag.astype(dtFloat), head)
-        hdu2 = pf.ImageHDU(np.abs(cleanFDF).astype(dtFloat), head)
-        hduLst = pf.HDUList([hdu0, hdu1, hdu2])
-        hduLst.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu0=pf.PrimaryHDU(cleanFDF.real.astype(dtFloat), head)
+        hdu1=pf.ImageHDU(cleanFDF.imag.astype(dtFloat), head)
+        hdu2=pf.ImageHDU(np.abs(cleanFDF).astype(dtFloat), head)
+        hduLst=pf.HDUList([hdu0, hdu1, hdu2])
+        hduLst.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         hduLst.close()
     else:
-        hdu0 = pf.PrimaryHDU(cleanFDF.real.astype(dtFloat), head)
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_clean_real.fits"
-        hdu0.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu0=pf.PrimaryHDU(cleanFDF.real.astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_clean_real.fits"
+        hdu0.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         if (verbose): log("> %s" % fitsFileOut)
-        hdu1 = pf.PrimaryHDU(cleanFDF.imag.astype(dtFloat), head)
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_clean_im.fits"
-        hdu1.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu1=pf.PrimaryHDU(cleanFDF.imag.astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_clean_im.fits"
+        hdu1.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         if (verbose): log("> %s" % fitsFileOut)
-        hdu2 = pf.PrimaryHDU(np.abs(cleanFDF).astype(dtFloat), head)
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_clean_tot.fits"
-        hdu2.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu2=pf.PrimaryHDU(np.abs(cleanFDF).astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_clean_tot.fits"
+        hdu2.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         if (verbose): log("> %s" % fitsFileOut)
 
     if not write_separate_FDF:
-    #Save the complex clean components as another file.
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_CC.fits"
+    # Save the complex clean components as another file.
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_CC.fits"
         if (verbose): log("> %s" % fitsFileOut)
-        hdu0 = pf.PrimaryHDU(ccArr.real.astype(dtFloat), head)
-        hdu1 = pf.ImageHDU(ccArr.imag.astype(dtFloat), head)
-        hdu2 = pf.ImageHDU(np.abs(ccArr).astype(dtFloat), head)
-        hduLst = pf.HDUList([hdu0, hdu1, hdu2])
-        hduLst.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu0=pf.PrimaryHDU(ccArr.real.astype(dtFloat), head)
+        hdu1=pf.ImageHDU(ccArr.imag.astype(dtFloat), head)
+        hdu2=pf.ImageHDU(np.abs(ccArr).astype(dtFloat), head)
+        hduLst=pf.HDUList([hdu0, hdu1, hdu2])
+        hduLst.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         hduLst.close()
     else:
-        hdu0 = pf.PrimaryHDU(ccArr.real.astype(dtFloat), head)
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_CC_real.fits"
-        hdu0.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu0=pf.PrimaryHDU(ccArr.real.astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_CC_real.fits"
+        hdu0.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         if (verbose): log("> %s" % fitsFileOut)
-        hdu1 = pf.PrimaryHDU(ccArr.imag.astype(dtFloat), head)
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_CC_im.fits"
-        hdu1.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu1=pf.PrimaryHDU(ccArr.imag.astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_CC_im.fits"
+        hdu1.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         if (verbose): log("> %s" % fitsFileOut)
-        hdu2 = pf.PrimaryHDU(np.abs(ccArr).astype(dtFloat), head)
-        fitsFileOut = outDir + "/" + prefixOut + "FDF_CC_tot.fits"
-        hdu2.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+        hdu2=pf.PrimaryHDU(np.abs(ccArr).astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_CC_tot.fits"
+        hdu2.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
+        if (verbose): log("> %s" % fitsFileOut)
+
+    if not write_separate_FDF:
+    # Save the complex residuals as another file.
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_resid.fits"
+        if (verbose): log("> %s" % fitsFileOut)
+        hdu0=pf.PrimaryHDU(residFDF.real.astype(dtFloat), head)
+        hdu1=pf.ImageHDU(residFDF.imag.astype(dtFloat), head)
+        hdu2=pf.ImageHDU(np.abs(residFDF).astype(dtFloat), head)
+        hduLst=pf.HDUList([hdu0, hdu1, hdu2])
+        hduLst.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
+        hduLst.close()
+    else:
+        hdu0=pf.PrimaryHDU(residFDF.real.astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_resid_real.fits"
+        hdu0.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
+        if (verbose): log("> %s" % fitsFileOut)
+        hdu1=pf.PrimaryHDU(residFDF.imag.astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_resid_im.fits"
+        hdu1.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
+        if (verbose): log("> %s" % fitsFileOut)
+        hdu2=pf.PrimaryHDU(np.abs(residFDF).astype(dtFloat), head)
+        fitsFileOut=outDir + "/" + prefixOut + "FDF_resid_tot.fits"
+        hdu2.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
         if (verbose): log("> %s" % fitsFileOut)
 
 
     # Save the iteration count mask
-    fitsFileOut = outDir + "/" + prefixOut + "CLEAN_nIter.fits"
+    fitsFileOut=outDir + "/" + prefixOut + "CLEAN_nIter.fits"
     if (verbose): log("> %s" % fitsFileOut)
-    head["BUNIT"] = "Iterations"
-    hdu0 = pf.PrimaryHDU(iterCountArr.astype(dtFloat), head)
-    hduLst = pf.HDUList([hdu0])
-    hduLst.writeto(fitsFileOut, output_verify="fix", overwrite=True)
+    head["BUNIT"]="Iterations"
+    hdu0=pf.PrimaryHDU(iterCountArr.astype(dtFloat), head)
+    hduLst=pf.HDUList([hdu0])
+    hduLst.writeto(fitsFileOut, output_verify = "fix", overwrite = True)
     hduLst.close()
 
 
@@ -249,32 +273,32 @@ def read_FDF_cube(filename):
     puts it first (in numpy order) to accommodate the rest of the code.
     Returns: (complex_cube, header,FD_axis)
     """
-    HDULst = pf.open(filename, "readonly", memmap=True)
-    head = HDULst[0].header.copy()
-    FDFreal = HDULst[0].data
-    FDFimag = HDULst[1].data
-    complex_cube = FDFreal + 1j * FDFimag
+    HDULst=pf.open(filename, "readonly", memmap = True)
+    head=HDULst[0].header.copy()
+    FDFreal=HDULst[0].data
+    FDFimag=HDULst[1].data
+    complex_cube=FDFreal + 1j * FDFimag
 
-    #Identify Faraday depth axis (assumed to be last one if not explicitly found)
+    # Identify Faraday depth axis (assumed to be last one if not explicitly found)
     Ndim=head['NAXIS']
     FD_axis=Ndim
-    #Check for FD axes:
-    for i in range(1,Ndim+1):
+    # Check for FD axes:
+    for i in range(1, Ndim+1):
         try:
             if 'FARADAY' in head['CTYPE'+str(i)].upper():
                 FD_axis=i
         except:
-            pass #The try statement is needed for if the FITS header does not
+            pass  # The try statement is needed for if the FITS header does not
                  # have CTYPE keywords.
 
-    #Move FD axis to first place in numpy order.
+    # Move FD axis to first place in numpy order.
     if FD_axis != Ndim:
-        complex_cube=np.moveaxis(complex_cube,Ndim-FD_axis,0)
+        complex_cube=np.moveaxis(complex_cube, Ndim-FD_axis, 0)
 
-    #Remove degenerate axes to prevent problems with later steps.
+    # Remove degenerate axes to prevent problems with later steps.
     complex_cube=complex_cube.squeeze()
 
-    return complex_cube, head,FD_axis
+    return complex_cube, head, FD_axis
 
 #-----------------------------------------------------------------------------#
 if __name__ == "__main__":

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -576,7 +576,8 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
 
             # Lets CONVOLVE
 
-            residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - np.convolve(ccArr, RMSFArr[:, yi, xi])
+            residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - np.convolve(ccArr[:,
+            yi, xi], RMSFArr[:, yi, xi])[2*nPhiPad-1:-2*nPhiPad+1]
 
 
             '''

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -550,7 +550,36 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
     if verbose:
         pass
         #progress(40, 0)  #This is currently broken...
-    for yi, xi in xyCoords:
+    pool.map(cleanloop, for xyCoord in xyCoords):
+
+
+
+        if doPlots:
+            plot_clean_spec(ax1,
+                            ax2,
+                            phiArr_radm2,
+                            dirtyFDF,
+                            ccArr,
+                            residFDF,
+                            cutoff)
+            ax1.lines[2].remove()
+            plt.draw()
+
+    # Restore the residual to the CLEANed FDF (moved outside of loop:
+        #will now work for pixels/spectra without clean components)
+    cleanFDF += residFDF
+
+
+    # Remove redundant dimensions
+    cleanFDF = np.squeeze(cleanFDF)
+    ccArr = np.squeeze(ccArr)
+    iterCountArr = np.squeeze(iterCountArr)
+
+    return cleanFDF, ccArr, iterCountArr
+
+#-----------------------------------------------------------------------------#
+def cleanloop(xyCoord):
+    yi, xi = xyCoord
         if verbose:
             j += 1
             #progress(40, ((j)*100.0/nCleanPix))  #This is currently broken...
@@ -610,30 +639,6 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
                                 ccArr,
                                 residFDF,
                                 cutoff)
-
-
-        if doPlots:
-            plot_clean_spec(ax1,
-                            ax2,
-                            phiArr_radm2,
-                            dirtyFDF,
-                            ccArr,
-                            residFDF,
-                            cutoff)
-            ax1.lines[2].remove()
-            plt.draw()
-
-    # Restore the residual to the CLEANed FDF (moved outside of loop:
-        #will now work for pixels/spectra without clean components)
-    cleanFDF += residFDF
-
-
-    # Remove redundant dimensions
-    cleanFDF = np.squeeze(cleanFDF)
-    ccArr = np.squeeze(ccArr)
-    iterCountArr = np.squeeze(iterCountArr)
-
-    return cleanFDF, ccArr, iterCountArr
 
 
 #-----------------------------------------------------------------------------#

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -552,9 +552,10 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
         #progress(40, 0)  #This is currently broken...
     inputs = [[yi, xi, verbose, RMSFArr, phi2Arr_radm2, phiArr_radm2, residFDF, cutoff, maxIter, gain, ccArr, dirtyFDF, cleanFDF, fwhmRMSFArr, iterCountArr] \
         for yi, xi in xyCoords]
-    pool.map(cleanloop, inputs)
+    output = np.array(pool.map(cleanloop, inputs))
     pool.close()
 
+    residFDF, ccArr, iterCountArr = output
     # Restore the residual to the CLEANed FDF (moved outside of loop:
         #will now work for pixels/spectra without clean components)
     cleanFDF += residFDF
@@ -610,6 +611,7 @@ def cleanloop(input):
             gauss1D(CC, phiPeak, fwhmRMSFArr[yi, xi])(phiArr_radm2)
         iterCount += 1
         iterCountArr[yi, xi] = iterCount
+    return residFDF, ccArr, iterCountArr
 
 
 #-----------------------------------------------------------------------------#

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -552,9 +552,8 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
         #progress(40, 0)  #This is currently broken...
     inputs = [[yi, xi, dirtyFDF] for yi, xi in xyCoords]
     rmc = RMcleaner(RMSFArr, phi2Arr_radm2, phiArr_radm2,fwhmRMSFArr, iterCountArr, maxIter, gain, cutoff, verbose)
-    output = pool.map(rmc.cleanloop, inputs)
+    output = list(pool.map(rmc.cleanloop, inputs))
     pool.close()
-
     # Put data back in correct shape
     ccArr = np.rot90(np.stack([model for _, _, model in output]), k=-1)
     cleanFDF = np.rot90(np.stack([clean for clean, _, _ in output]), k=-1)

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -393,7 +393,6 @@ def get_rmsf_planes(lambdaSqArr_m2, phiArr_radm2, weightArr=None, mskArr=None,
 
 
 #-----------------------------------------------------------------------------#
-@profile
 def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
                       fwhmRMSFArr, cutoff, maxIter=1000, gain=0.1,
                       mskArr=None, nBits=32, verbose=False, doPlots=False,

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -71,7 +71,7 @@ from scipy.stats import anderson
 from scipy.stats import kstest
 from scipy.stats import norm
 
-from scipy.signal import convolve
+from scipy import signal
 
 from RMutils.mpfit import mpfit
 from RMutils.util_misc import progress
@@ -578,8 +578,8 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
 
             # Lets CONVOLVE
 
-            residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - convolve(ccArr[:,
-            yi, xi], RMSFArr[:, yi, xi], mode = 'valid')[2*nPhiPad-1:-2*nPhiPad+1]
+            residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - signal.fftconvolve(ccArr[:,
+            yi, xi], RMSFArr[:, yi, xi], mode = 'valid')[1:-1]
 
 
             '''

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -71,6 +71,8 @@ from scipy.stats import anderson
 from scipy.stats import kstest
 from scipy.stats import norm
 
+from scipy.signal import convolve
+
 from RMutils.mpfit import mpfit
 from RMutils.util_misc import progress
 from RMutils.util_misc import toscalar
@@ -576,7 +578,7 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
 
             # Lets CONVOLVE
 
-            residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - np.convolve(ccArr[:,
+            residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - convolve(ccArr[:,
             yi, xi], RMSFArr[:, yi, xi])[2*nPhiPad-1:-2*nPhiPad+1]
 
 

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -72,6 +72,7 @@ from scipy.stats import kstest
 from scipy.stats import norm
 
 from scipy import signal
+import tqdm
 
 from RMutils.mpfit import mpfit
 from RMutils.util_misc import progress
@@ -177,14 +178,16 @@ def do_rmsynth_planes(dataQ, dataU, lambdaSqArr_m2, phiArr_radm2,
     # Do the RM-synthesis on each plane
     if verbose:
         log("Running RM-synthesis by channel.")
-        progress(40, 0)
+        pbar = tqdm.tqdm(total=nPhi)
     a = lambdaSqArr_m2 - lam0Sq_m2
+
     for i in range(nPhi):
         if verbose:
-            progress(40, ((i+1)*100.0/nPhi))
+            pbar.update()
         arg = np.exp(-2.0j * phiArr_radm2[i] * a)[:, np.newaxis,np.newaxis]
         FDFcube[i,:,:] =  KArr * np.sum(pCube * arg, axis=0)
-
+    if verbose:
+        pbar.close()
     # Remove redundant dimensions in the FDF array
     FDFcube = np.squeeze(FDFcube)
 

--- a/RMutils/util_RM.py
+++ b/RMutils/util_RM.py
@@ -579,7 +579,7 @@ def do_rmclean_hogbom(dirtyFDF, phiArr_radm2, RMSFArr, phi2Arr_radm2,
             # Lets CONVOLVE
 
             residFDF[:, yi, xi] = dirtyFDF[:, yi, xi] - convolve(ccArr[:,
-            yi, xi], RMSFArr[:, yi, xi])[2*nPhiPad-1:-2*nPhiPad+1]
+            yi, xi], RMSFArr[:, yi, xi], mode = 'valid')[2*nPhiPad-1:-2*nPhiPad+1]
 
 
             '''


### PR DESCRIPTION
Three major changes are implemented:

1. Parallelisation of RM Clean: This is done using the package [Schwimmbad](https://schwimmbad.readthedocs.io/en/latest/#). This allows CLEAN to be run in parallel with flexibility in the implementation (e.g. serial, multiprocessing, or MPI).

2. Residuals are now returned from CLEAN: Following this they are also saved in the 1D/3D scripts.

3. Progress bars: These are implemented using [tqdm](https://tqdm.github.io/). Currently this is not implemented in CLEAN (parallel progress bars seem to be a fit fiddly).
